### PR TITLE
update jamsocket dep, README, jamsocket config

### DIFF
--- a/jamsocket.config.js
+++ b/jamsocket.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   dockerfile: './Dockerfile.jamsocket',
-  service: 'whiteboard-demo',
   watch: ['./src/session-backend'],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "jamsocket-nextjs-tutorial",
       "version": "0.1.0",
       "dependencies": {
-        "@jamsocket/javascript": "^0.1.1",
+        "@jamsocket/javascript": "^0.1.2",
         "@types/node": "20.1.4",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
@@ -137,9 +137,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@jamsocket/javascript": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jamsocket/javascript/-/javascript-0.1.1.tgz",
-      "integrity": "sha512-vm346eVkv9I9l/r1XRSqRQtUR259BprsOnKFOXAJgOarXwp/t7V9FrIBWNSfeJsC3epaWLsBbTQ5VgMd27whBA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@jamsocket/javascript/-/javascript-0.1.2.tgz",
+      "integrity": "sha512-+f2xSo2y7pKnSdJM7rkY/iI19p+J11jqiD+Q96+jwBw7Ik37xMcq9X+cnYq/8xSAADUhwdavcntQiDDKm+SUxg==",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
         "server-only": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@jamsocket/javascript": "^0.1.1",
+    "@jamsocket/javascript": "^0.1.2",
     "@types/node": "20.1.4",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",


### PR DESCRIPTION
These are some changes to make sure this demo works with the newest version of the dev CLI. Let's wait until that version has been published before we land this, though. (`npx jamsocket@latest --version` should be >=0.8.0)

Also need to fully update the README to match the changes that are landing in the docs before we merge this.
Also, remember to rebase the `completed` branch once this lands.